### PR TITLE
Remove displayed TOC end tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A place to define the conventions we use to build APIs
 
 <!-- /TOC -->
 
-
 ## Basic Tools
 
 It's quite common in Hyper to build APIs with [Ruby on Rails](http://rubyonrails.org/), so most of these

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ A place to define the conventions we use to build APIs
 			- [Generate structured errors](#generate-structured-errors)
 			- [Show rate limit status](#show-rate-limit-status)
 			- [Keep JSON minified in all responses](#keep-json-minified-in-all-responses)
+
 <!-- /TOC -->
+
 
 ## Basic Tools
 


### PR DESCRIPTION
This makes sure that the `<!-- /TOC -->` tag doesn't appear in the README on GitHub.
